### PR TITLE
Add support for V3 of the TrueTime API

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -1,0 +1,15 @@
+[[source]]
+url = "https://pypi.org/simple"
+verify_ssl = true
+name = "pypi"
+
+[packages]
+requests = ">=2.0.0"
+xmltodict = ">=0.9.0"
+pytz = "*"
+beautifulsoup4 = "*"
+
+[dev-packages]
+
+[requires]
+python_version = "3.9"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,0 +1,92 @@
+{
+    "_meta": {
+        "hash": {
+            "sha256": "2c5a79983814dc3545b3ea753c90cbc79587b77a5a02051f7a2b8bb048d3abd4"
+        },
+        "pipfile-spec": 6,
+        "requires": {
+            "python_version": "3.9"
+        },
+        "sources": [
+            {
+                "name": "pypi",
+                "url": "https://pypi.org/simple",
+                "verify_ssl": true
+            }
+        ]
+    },
+    "default": {
+        "beautifulsoup4": {
+            "hashes": [
+                "sha256:9a315ce70049920ea4572a4055bc4bd700c940521d36fc858205ad4fcde149bf",
+                "sha256:c23ad23c521d818955a4151a67d81580319d4bf548d3d49f4223ae041ff98891"
+            ],
+            "index": "pypi",
+            "version": "==4.10.0"
+        },
+        "certifi": {
+            "hashes": [
+                "sha256:78884e7c1d4b00ce3cea67b44566851c4343c120abd683433ce934a68ea58872",
+                "sha256:d62a0163eb4c2344ac042ab2bdf75399a71a2d8c7d47eac2e2ee91b9d6339569"
+            ],
+            "version": "==2021.10.8"
+        },
+        "charset-normalizer": {
+            "hashes": [
+                "sha256:e019de665e2bcf9c2b64e2e5aa025fa991da8720daa3c1138cadd2fd1856aed0",
+                "sha256:f7af805c321bfa1ce6714c51f254e0d5bb5e5834039bc17db7ebe3a4cec9492b"
+            ],
+            "markers": "python_version >= '3'",
+            "version": "==2.0.7"
+        },
+        "idna": {
+            "hashes": [
+                "sha256:84d9dd047ffa80596e0f246e2eab0b391788b0503584e8945f2368256d2735ff",
+                "sha256:9d643ff0a55b762d5cdb124b8eaa99c66322e2157b69160bc32796e824360e6d"
+            ],
+            "markers": "python_version >= '3'",
+            "version": "==3.3"
+        },
+        "pytz": {
+            "hashes": [
+                "sha256:3672058bc3453457b622aab7a1c3bfd5ab0bdae451512f6cf25f64ed37f5b87c",
+                "sha256:acad2d8b20a1af07d4e4c9d2e9285c5ed9104354062f275f3fcd88dcef4f1326"
+            ],
+            "index": "pypi",
+            "version": "==2021.3"
+        },
+        "requests": {
+            "hashes": [
+                "sha256:6c1246513ecd5ecd4528a0906f910e8f0f9c6b8ec72030dc9fd154dc1a6efd24",
+                "sha256:b8aa58f8cf793ffd8782d3d8cb19e66ef36f7aba4353eec859e74678b01b07a7"
+            ],
+            "index": "pypi",
+            "version": "==2.26.0"
+        },
+        "soupsieve": {
+            "hashes": [
+                "sha256:617ffc4d0dfd39c66f4d1413a6e165663a34eca86be9b54f97b91756300ff6df",
+                "sha256:e4860f889dfa88774c07da0b276b70c073b6470fa1a4a8350800bb7bce3dcc76"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==2.3"
+        },
+        "urllib3": {
+            "hashes": [
+                "sha256:4987c65554f7a2dbf30c18fd48778ef124af6fab771a377103da0585e2336ece",
+                "sha256:c4fdf4019605b6e5423637e01bc9fe4daef873709a7973e195ceba0a62bbc844"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4' and python_version < '4'",
+            "version": "==1.26.7"
+        },
+        "xmltodict": {
+            "hashes": [
+                "sha256:50d8c638ed7ecb88d90561beedbf720c9b4e851a9fa6c47ebd64e99d166d8a21",
+                "sha256:8bbcb45cc982f48b2ca8fe7e7827c5d792f217ecf1792626f808bf41c3b86051"
+            ],
+            "index": "pypi",
+            "version": "==0.12.0"
+        }
+    },
+    "develop": {}
+}

--- a/pghbustime/interface.py
+++ b/pghbustime/interface.py
@@ -3,6 +3,7 @@ from builtins import str
 from builtins import map
 from builtins import zip
 from builtins import object
+from urllib.parse import quote_plus
 import requests
 import xmltodict
 import sys
@@ -41,29 +42,31 @@ class BustimeAPI(object):
     http://realtime.portauthority.org/bustime/apidoc/v1/main.jsp?section=documentation.jsp
     """
     
-    __api_version__ = 'v1'
+    __api_version__ = 'v3'
     
     ENDPOINTS = dict(
-        SYSTIME = "http://realtime.portauthority.org/bustime/api/v1/gettime",
-        VEHICLES = "http://realtime.portauthority.org/bustime/api/v1/getvehicles",
-        ROUTES = "http://realtime.portauthority.org/bustime/api/v1/getroutes",
-        R_DIRECTIONS = "http://realtime.portauthority.org/bustime/api/v1/getdirections",
-        STOPS = "http://realtime.portauthority.org/bustime/api/v1/getstops",
-        R_GEO = "http://realtime.portauthority.org/bustime/api/v1/getpatterns",
-        PREDICTION = "http://realtime.portauthority.org/bustime/api/v1/getpredictions",
-        BULLETINS = "http://realtime.portauthority.org/bustime/api/v1/getservicebulletins"
+        SYSTIME = "http://realtime.portauthority.org/bustime/api/v3/gettime",
+        VEHICLES = "http://realtime.portauthority.org/bustime/api/v3/getvehicles",
+        ROUTES = "http://realtime.portauthority.org/bustime/api/v3/getroutes",
+        R_DIRECTIONS = "http://realtime.portauthority.org/bustime/api/v3/getdirections",
+        STOPS = "http://realtime.portauthority.org/bustime/api/v3/getstops",
+        R_GEO = "http://realtime.portauthority.org/bustime/api/v3/getpatterns",
+        PREDICTION = "http://realtime.portauthority.org/bustime/api/v3/getpredictions",
+        BULLETINS = "http://realtime.portauthority.org/bustime/api/v3/getservicebulletins"
     )
     
     RESPONSE_TOKEN = "bustime-response"
     ERROR_TOKEN = "error"
     STRPTIME = "%Y%m%d %H:%M:%S"
+    RTPI_DATAFEED_NAME = "Port Authority Bus"
     
-    def __init__(self, apikey, locale="en_US", _format="json", tmres="s"):
+    def __init__(self, apikey, locale="en_US", _format="json", tmres="s", rtpidatafeed = RTPI_DATAFEED_NAME):
         self.key = apikey
         self.format = _format
         self.args = dict(
             localestring = locale,
-            tmres = tmres
+            tmres = tmres,
+            rtpidatafeed = quote_plus(rtpidatafeed), # feed name may include spaces
         )
             
     def endpoint(self, endpt, argdict=None):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 requests>=2.0.0
 xmltodict>=0.9.0
 pytz
-BeautifulSoup
+beautifulsoup4

--- a/tests.py
+++ b/tests.py
@@ -10,11 +10,11 @@ class TestAPI(unittest.TestCase):
         
 class TestEndpoint(TestAPI):
     def test_vehicle(self):
-        url = "http://realtime.portauthority.org/bustime/api/v1/getvehicles?key=BOGUSAPIKEY&localestring=en_US&tmres=s"
+        url = "http://realtime.portauthority.org/bustime/api/v3/getvehicles?key=BOGUSAPIKEY&localestring=en_US&rtpidatafeed=Port+Authority+Bus&tmres=s"
         self.assertEqual( self.api.endpoint('VEHICLES'), url )
     
     def test_pdict(self):
-        url = 'http://realtime.portauthority.org/bustime/api/v1/getpredictions?key=BOGUSAPIKEY&localestring=en_US&tmres=s&rt=28X&stpid=4123'
+        url = 'http://realtime.portauthority.org/bustime/api/v3/getpredictions?key=BOGUSAPIKEY&localestring=en_US&rtpidatafeed=Port+Authority+Bus&tmres=s&rt=28X&stpid=4123'
         generated = self.api.endpoint('PREDICTION', dict(stpid=4123, rt='28X') )
         self.assertEqual( generated, url )
         


### PR DESCRIPTION
Looks like the Port Authority has dropped support for V1 (and V2) of the TrueTime API, since all of my requests are returning an error with the message "No data found for parameter". V3 of the API works as expected, so I added support for the new `rtpidatafeed` parameter that it requires.